### PR TITLE
fix: vanilla denoise option doesn't persist

### DIFF
--- a/lib/controllers/audio_settings_controller.dart
+++ b/lib/controllers/audio_settings_controller.dart
@@ -36,7 +36,7 @@ class AudioSettingsController with ChangeNotifier {
     soundVolume = await options.getDouble('soundVolume') ?? -10;
     inputSensitivity = await options.getDouble('inputSensitivity') ?? -16;
     useDenoise = await options.getBool('useDenoise') ?? true;
-    denoiseModel = await options.getString('denoiseModel') ?? 'Hogwash';
+    denoiseModel = await options.getString('denoiseModel') ?? 'Vanilla';
     outputDeviceId = await options.getString('outputDeviceId');
     inputDeviceId = await options.getString('inputDeviceId');
 

--- a/lib/core/utils/asset_loader.dart
+++ b/lib/core/utils/asset_loader.dart
@@ -14,7 +14,7 @@ Future<List<int>> readAssetBytes(String assetName) async {
 }
 
 Future<void> updateDenoiseModel(String? model, Telepathy telepathy) async {
-  if (model == null) {
+  if (model == null || model == 'Vanilla') {
     telepathy.setModel(model: null);
     return;
   }

--- a/lib/screens/settings/sections/audio_settings.dart
+++ b/lib/screens/settings/sections/audio_settings.dart
@@ -229,18 +229,15 @@ class _AudioSettingsState extends State<AudioSettings> {
                         // set denoise to false
                         telepathy.setDenoise(denoise: false);
                       } else {
-                        if (value == 'Vanilla') {
-                          value = null;
-                        }
-
-                        // save denoise option
+                          // save denoise option
                         audioSettingsController.updateUseDenoise(true);
                         // save denoise model
                         audioSettingsController.setDenoiseModel(value);
                         // set denoise to true
                         telepathy.setDenoise(denoise: true);
-                        // set denoise model
-                        updateDenoiseModel(value, telepathy);
+                        // set denoise model — pass null for Vanilla (built-in default)
+                        updateDenoiseModel(
+                            value == 'Vanilla' ? null : value, telepathy);
                       }
                     });
               },


### PR DESCRIPTION
Closes #21

Fixes persistence of the vanilla denoising model selection across app restarts.