### PR TITLE
fix: submit create profile dialog with enter

### DIFF
--- a/lib/screens/settings/sections/profiles.dart
+++ b/lib/screens/settings/sections/profiles.dart
@@ -18,6 +18,15 @@ class ProfileSettings extends StatefulWidget {
 class ProfileSettingsState extends State<ProfileSettings> {
   final TextEditingController _profileNameInput = TextEditingController();
 
+  void _createProfile(
+    BuildContext dialogContext,
+    ProfilesController profilesController,
+  ) {
+    profilesController.createProfile(_profileNameInput.text);
+    _profileNameInput.clear();
+    Navigator.of(dialogContext).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final profilesController = context.watch<ProfilesController>();
@@ -151,30 +160,34 @@ class ProfileSettingsState extends State<ProfileSettings> {
                 showDialog(
                     context: context,
                     builder: (BuildContext context) {
-                      return SimpleDialog(
-                        title: const Text('Create Profile'),
-                        contentPadding: const EdgeInsets.only(
-                            bottom: 25, left: 25, right: 25),
-                        titlePadding: const EdgeInsets.only(
-                            top: 25, left: 25, right: 25, bottom: 15),
-                        children: [
-                          TextField(
-                            decoration: const InputDecoration(
-                              labelText: 'Name',
+                      return CallbackShortcuts(
+                        bindings: <ShortcutActivator, VoidCallback>{
+                          const SingleActivator(LogicalKeyboardKey.enter): () =>
+                              _createProfile(context, profilesController),
+                        },
+                        child: SimpleDialog(
+                          title: const Text('Create Profile'),
+                          contentPadding: const EdgeInsets.only(
+                              bottom: 25, left: 25, right: 25),
+                          titlePadding: const EdgeInsets.only(
+                              top: 25, left: 25, right: 25, bottom: 15),
+                          children: [
+                            TextField(
+                              decoration: const InputDecoration(
+                                labelText: 'Name',
+                              ),
+                              controller: _profileNameInput,
+                              onSubmitted: (_) =>
+                                  _createProfile(context, profilesController),
                             ),
-                            controller: _profileNameInput,
-                          ),
-                          const SizedBox(height: 20),
-                          Button(
-                            text: 'Create',
-                            onPressed: () {
-                              profilesController
-                                  .createProfile(_profileNameInput.text);
-                              _profileNameInput.clear();
-                              Navigator.of(context).pop();
-                            },
-                          )
-                        ],
+                            const SizedBox(height: 20),
+                            Button(
+                              text: 'Create',
+                              onPressed: () =>
+                                  _createProfile(context, profilesController),
+                            )
+                          ],
+                        ),
                       );
                     });
               },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -475,26 +475,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -799,7 +799,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
@@ -935,10 +935,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  shared_preferences_platform_interface: ^2.4.1
 
   flutter_lints: ^6.0.0
   freezed: ^3.0.0

--- a/test/screens/settings/sections/profiles_test.dart
+++ b/test/screens/settings/sections/profiles_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:telepathy/controllers/index.dart';
+import 'package:telepathy/core/rust/flutter.dart';
+import 'package:telepathy/core/rust/lib.dart';
+import 'package:telepathy/core/rust/types.dart';
+import 'package:telepathy/models/index.dart';
+import 'package:telepathy/screens/settings/sections/profiles.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+  });
+
+  tearDown(() {
+    SharedPreferencesAsyncPlatform.instance = null;
+  });
+
+  testWidgets('pressing Enter in create dialog creates a profile', (
+    WidgetTester tester,
+  ) async {
+    final profilesController = FakeProfilesController();
+
+    await tester.pumpProfileSettings(profilesController);
+    await tester.openCreateProfileDialog();
+
+    await tester.enterText(find.byType(TextField), 'Keyboard Profile');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Profile'), findsNothing);
+    expect(find.text('Keyboard Profile'), findsOneWidget);
+    expect(profilesController.createdNames, <String>['Keyboard Profile']);
+
+    await tester.openCreateProfileDialog();
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.controller?.text, isEmpty);
+  });
+
+  testWidgets('Create button still creates a profile', (
+    WidgetTester tester,
+  ) async {
+    final profilesController = FakeProfilesController();
+
+    await tester.pumpProfileSettings(profilesController);
+    await tester.openCreateProfileDialog();
+
+    await tester.enterText(find.byType(TextField), 'Button Profile');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Profile'), findsNothing);
+    expect(find.text('Button Profile'), findsOneWidget);
+    expect(profilesController.createdNames, <String>['Button Profile']);
+  });
+}
+
+extension on WidgetTester {
+  Future<void> pumpProfileSettings(FakeProfilesController profilesController) {
+    return pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ProfilesController>.value(
+            value: profilesController,
+          ),
+          ChangeNotifierProvider<StateController>.value(
+            value: StateController(),
+          ),
+          Provider<Telepathy>.value(value: FakeTelepathy()),
+        ],
+        child: const MaterialApp(home: Scaffold(body: ProfileSettings())),
+      ),
+    );
+  }
+
+  Future<void> openCreateProfileDialog() async {
+    await tap(find.byTooltip('Create Profile'));
+    await pumpAndSettle();
+    expect(find.text('Create Profile'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+  }
+}
+
+class FakeProfilesController extends ProfilesController {
+  FakeProfilesController()
+      : super(
+          storage: const FlutterSecureStorage(),
+          options: SharedPreferencesAsync(),
+        );
+
+  final List<String> createdNames = <String>[];
+  int _nextProfileId = 0;
+
+  @override
+  Future<String> createProfile(String nickname) async {
+    final id = 'profile-${_nextProfileId++}';
+    createdNames.add(nickname);
+    profiles[id] = Profile(
+      id: id,
+      nickname: nickname.trim().isEmpty ? 'Unnamed Profile' : nickname,
+      peerId: 'peer-$id',
+      keypair: const <int>[],
+      contacts: <String, Contact>{},
+      rooms: <String, Room>{},
+    );
+    notifyListeners();
+    return id;
+  }
+}
+
+class FakeTelepathy implements Telepathy {
+  @override
+  bool get isDisposed => false;
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<void> audioTest() async {}
+
+  @override
+  ChatMessage buildChat({
+    required Contact contact,
+    required String text,
+    required List<(String, Uint8List)> attachments,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> endCall() async {}
+
+  @override
+  Future<void> joinRoom({required List<String> memberStrings}) async {}
+
+  @override
+  Future<(List<AudioDevice>, List<AudioDevice>)> listDevices() async =>
+      (<AudioDevice>[], <AudioDevice>[]);
+
+  @override
+  void pauseStatistics() {}
+
+  @override
+  Future<void> restartManager() async {}
+
+  @override
+  void resumeStatistics() {}
+
+  @override
+  Future<void> sendChat({required ChatMessage message}) async {}
+
+  @override
+  void setDeafened({required bool deafened}) {}
+
+  @override
+  void setDenoise({required bool denoise}) {}
+
+  @override
+  void setEfficiencyMode({required bool enabled}) {}
+
+  @override
+  Future<void> setIdentity({required List<int> key}) async {}
+
+  @override
+  Future<void> setInputDevice({String? deviceId}) async {}
+
+  @override
+  void setInputVolume({required double decibel}) {}
+
+  @override
+  Future<void> setModel({Uint8List? model}) async {}
+
+  @override
+  void setMuted({required bool muted}) {}
+
+  @override
+  Future<void> setOutputDevice({String? deviceId}) async {}
+
+  @override
+  void setOutputVolume({required double decibel}) {}
+
+  @override
+  void setPlayCustomRingtones({required bool play}) {}
+
+  @override
+  void setRmsThreshold({required double decimal}) {}
+
+  @override
+  void setSendCustomRingtone({required bool send}) {}
+
+  @override
+  Future<void> shutdown() async {}
+
+  @override
+  Future<void> startCall({required Contact contact}) async {}
+
+  @override
+  Future<void> startManager() async {}
+
+  @override
+  Future<void> startScreenshare({required Contact contact}) async {}
+
+  @override
+  Future<void> startSession({required Contact contact}) async {}
+
+  @override
+  Future<void> stopSession({required Contact contact}) async {}
+}


### PR DESCRIPTION
## Summary

Creating a profile can now be submitted from the keyboard when the create-profile dialog is open. Enter uses the same path as the existing Create button, so the dialog closes and the input is cleared consistently.

Closes #27.

## Tests

- `flutter analyze lib/screens/settings/sections/profiles.dart test/screens/settings/sections/profiles_test.dart`
- `flutter test test/screens/settings/sections/profiles_test.dart`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)
