### PR TITLE
Expose audio stream error callbacks

### DIFF
--- a/rust/telepathy-audio/src/io/input.rs
+++ b/rust/telepathy-audio/src/io/input.rs
@@ -72,6 +72,7 @@ use crate::internal::thread::{self, JoinHandle};
 use crate::internal::traits::AudioInput;
 #[cfg(all(not(target_family = "wasm"), not(feature = "mock-audio")))]
 use crate::internal::traits::{CHANNEL_SIZE, RingBufferInput};
+use crate::io::StreamErrorCallback;
 use crate::io::traits::AudioDataSink;
 #[cfg(all(not(target_family = "wasm"), feature = "mock-audio"))]
 use crate::mock::MockAudioInput;
@@ -92,7 +93,6 @@ use std::sync::Arc;
 #[cfg(all(not(target_family = "wasm"), not(feature = "mock-audio")))]
 use std::sync::Condvar;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
-use tokio::sync::Notify;
 use tracing::{debug, error};
 
 /// Configuration for audio input processing.
@@ -107,7 +107,6 @@ use tracing::{debug, error};
 /// rate). When `denoise_enabled` is `false`, the processor passes through at
 /// the device's native sample rate. The encoder sample rate automatically
 /// matches the processor's output rate.
-#[derive(Clone)]
 pub struct AudioInputConfig {
     /// Device ID for input device selection.
     ///
@@ -140,12 +139,11 @@ pub struct AudioInputConfig {
     ///
     /// Higher values provide better quality but larger encoded size.
     pub codec_residual_bits: f32,
-    /// Optional notify handle for stream errors.
+    /// Optional callback for stream errors.
     ///
-    /// When set, the notify is triggered via `notify_one()` whenever a
-    /// stream error occurs, in addition to logging the error. Useful for
-    /// async error handling and reconnection logic.
-    pub error_notify: Option<Arc<Notify>>,
+    /// When set, the callback receives the underlying CPAL stream error.
+    /// When unset, stream errors are logged by default.
+    pub error_callback: Option<StreamErrorCallback>,
     /// Optional output sample rate override (only used when denoise is disabled).
     ///
     /// When set and `denoise_enabled` is `false`, the processor will resample
@@ -168,7 +166,7 @@ impl Default for AudioInputConfig {
             codec_enabled: false,
             codec_mode: CodecBitrateMode::Cbr,
             codec_residual_bits: 5.0,
-            error_notify: None,
+            error_callback: None,
             output_sample_rate: None,
         }
     }
@@ -331,12 +329,14 @@ where
         self
     }
 
-    /// Sets a notify handle to be triggered on stream errors.
+    /// Sets a callback to be triggered on stream errors.
     ///
-    /// When set, the notify will be triggered via `notify_one()` whenever
-    /// a stream error occurs, in addition to logging the error.
-    pub fn on_error(mut self, notify: &Arc<Notify>) -> Self {
-        self.config.error_notify = Some(notify.clone());
+    /// When set, the callback receives the underlying CPAL stream error.
+    pub fn on_error<F>(mut self, callback: F) -> Self
+    where
+        F: FnMut(cpal::StreamError) + Send + 'static,
+    {
+        self.config.error_callback = Some(Box::new(callback));
         self
     }
 
@@ -548,7 +548,7 @@ where
     /// - The stream cannot be created
     /// - The device uses an unsupported sample format
     #[cfg(all(not(target_family = "wasm"), not(feature = "mock-audio")))]
-    pub fn build(self, host: &impl AudioHost) -> Result<AudioInputHandle, Error> {
+    pub fn build(mut self, host: &impl AudioHost) -> Result<AudioInputHandle, Error> {
         if self.sink.is_none() {
             return Err(Error::Config(
                 "a data sink must be set via callback() or sink()".to_string(),
@@ -574,9 +574,9 @@ where
             producer: input_producer,
             notify: input_notify.clone(),
         };
-        // Create processor input and extract error_notify before consuming self
+        // Create processor input and extract error callback before consuming self
         let processor_input = RingBufferInput::new(input_consumer, input_notify);
-        let error_notify = self.config.error_notify.clone();
+        let error_callback = self.config.error_callback.take();
         // Build common components (channels, threads, state)
         let context = self.build_common(processor_input, device_sample_rate)?;
 
@@ -587,70 +587,70 @@ where
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I16 => build_input_stream_with_format::<i16>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I32 => build_input_stream_with_format::<i32>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I64 => build_input_stream_with_format_64::<i64>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U8 => build_input_stream_with_format::<u8>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U16 => build_input_stream_with_format::<u16>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U32 => build_input_stream_with_format::<u32>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U64 => build_input_stream_with_format_64::<u64>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::F32 => build_input_stream_with_format::<f32>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::F64 => build_input_stream_with_format_64::<f64>(
                 device,
                 &config.into(),
                 input_sender,
                 input_channels,
-                error_notify,
+                error_callback,
             )?,
             _ => return Err(Error::Config("Unsupported sample format".to_string())),
         };
@@ -873,14 +873,14 @@ impl Drop for RingBufferSender {
 /// * `config` - Stream configuration (sample rate, channels, etc.)
 /// * `input_producer` - Ring buffer producer for f32 samples to the processor
 /// * `input_channels` - Number of input channels
-/// * `error_notify` - Optional notify handle for stream errors
+/// * `error_callback` - Optional callback for stream errors
 #[cfg(all(not(target_family = "wasm"), not(feature = "mock-audio")))]
 fn build_input_stream_with_format<T>(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     mut input_sender: RingBufferSender,
     input_channels: usize,
-    error_notify: Option<Arc<Notify>>,
+    mut error_callback: Option<StreamErrorCallback>,
 ) -> Result<cpal::Stream, Error>
 where
     T: Sample<Float = f32> + cpal::SizedSample + Send + 'static,
@@ -901,9 +901,10 @@ where
             );
         },
         move |err| {
-            error!(error = %err, "input_stream_error");
-            if let Some(ref notify) = error_notify {
-                notify.notify_one();
+            if let Some(callback) = error_callback.as_mut() {
+                callback(err);
+            } else {
+                error!(error = %err, "input_stream_error");
             }
         },
         None,
@@ -922,7 +923,7 @@ fn build_input_stream_with_format_64<T>(
     config: &cpal::StreamConfig,
     mut input_sender: RingBufferSender,
     input_channels: usize,
-    error_notify: Option<Arc<Notify>>,
+    mut error_callback: Option<StreamErrorCallback>,
 ) -> Result<cpal::Stream, Error>
 where
     T: Sample<Float = f64> + cpal::SizedSample + Send + 'static,
@@ -944,9 +945,10 @@ where
             );
         },
         move |err| {
-            error!(error = %err, "input_stream_error");
-            if let Some(ref notify) = error_notify {
-                notify.notify_one();
+            if let Some(callback) = error_callback.as_mut() {
+                callback(err);
+            } else {
+                error!(error = %err, "input_stream_error");
             }
         },
         None,

--- a/rust/telepathy-audio/src/io/mod.rs
+++ b/rust/telepathy-audio/src/io/mod.rs
@@ -43,6 +43,8 @@ pub mod input;
 pub mod output;
 pub mod traits;
 
+pub type StreamErrorCallback = Box<dyn FnMut(cpal::StreamError) + Send + 'static>;
+
 // Re-export main types for convenience
 pub use input::{AudioInputBuilder, AudioInputConfig, AudioInputHandle, CodecBitrateMode};
 pub use output::{AudioOutputBuilder, AudioOutputConfig, AudioOutputHandle};

--- a/rust/telepathy-audio/src/io/output.rs
+++ b/rust/telepathy-audio/src/io/output.rs
@@ -42,8 +42,8 @@ use crate::internal::traits::CHANNEL_SIZE;
 use crate::internal::traits::RingBufferOutput;
 #[cfg(not(feature = "mock-audio"))]
 use crate::internal::utils::{hann_fade_in, hann_fade_out};
-use crate::io::SendStream;
 use crate::io::traits::AudioDataSource;
+use crate::io::{SendStream, StreamErrorCallback};
 #[cfg(feature = "mock-audio")]
 use crate::mock::MockAudioOutput;
 use crate::sea::codec::file::SeaFileHeader;
@@ -60,7 +60,6 @@ use nnnoiseless::FRAME_SIZE;
 use rtrb::chunks::ChunkError;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::Relaxed};
-use tokio::sync::Notify;
 use tracing::{debug, error};
 
 /// Configuration for audio output processing.
@@ -85,12 +84,11 @@ pub struct AudioOutputConfig {
     pub volume: f32,
     /// Set to true when codec is enabled
     pub codec_enabled: bool,
-    /// Optional notify handle for stream errors.
+    /// Optional callback for stream errors.
     ///
-    /// When set, the notify is triggered via `notify_one()` whenever a
-    /// stream error occurs, in addition to logging the error. Useful for
-    /// async error handling and reconnection logic.
-    pub error_notify: Option<Arc<Notify>>,
+    /// When set, the callback receives the underlying CPAL stream error.
+    /// When unset, stream errors are logged by default.
+    pub error_callback: Option<StreamErrorCallback>,
 }
 
 impl Default for AudioOutputConfig {
@@ -100,7 +98,7 @@ impl Default for AudioOutputConfig {
             sample_rate: 48_000,
             volume: 1.0,
             codec_enabled: false,
-            error_notify: None,
+            error_callback: None,
         }
     }
 }
@@ -232,12 +230,14 @@ where
         self
     }
 
-    /// Sets a notify handle to be triggered on stream errors.
+    /// Sets a callback to be triggered on stream errors.
     ///
-    /// When set, the notify will be triggered via `notify_one()` whenever
-    /// a stream error occurs, in addition to logging the error.
-    pub fn on_error(mut self, notify: Arc<Notify>) -> Self {
-        self.config.error_notify = Some(notify);
+    /// When set, the callback receives the underlying CPAL stream error.
+    pub fn on_error<F>(mut self, callback: F) -> Self
+    where
+        F: FnMut(cpal::StreamError) + Send + 'static,
+    {
+        self.config.error_callback = Some(Box::new(callback));
         self
     }
 
@@ -337,7 +337,7 @@ where
     /// - The stream cannot be created
     /// - The device uses an unsupported sample format
     #[cfg(not(feature = "mock-audio"))]
-    pub fn build(self, host: &impl AudioHost) -> Result<AudioOutputHandle, Error> {
+    pub fn build(mut self, host: &impl AudioHost) -> Result<AudioOutputHandle, Error> {
         use rtrb::RingBuffer;
         if self.source.is_none() {
             return Err(Error::Config(
@@ -360,7 +360,7 @@ where
 
         // Create processor output and build common components
         let processor_output = RingBufferOutput::new(output_producer);
-        let error_notify = self.config.error_notify.clone();
+        let error_callback = self.config.error_callback.take();
         let context = self.build_common(processor_output, output_sample_rate)?;
 
         // Build the audio stream with the appropriate sample format
@@ -370,70 +370,70 @@ where
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I16 => build_output_stream_with_format::<i16>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I32 => build_output_stream_with_format::<i32>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::I64 => build_output_stream_with_format::<i64>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U8 => build_output_stream_with_format::<u8>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U16 => build_output_stream_with_format::<u16>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U32 => build_output_stream_with_format::<u32>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::U64 => build_output_stream_with_format::<u64>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::F32 => build_output_stream_with_format::<f32>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             SampleFormat::F64 => build_output_stream_with_format::<f64>(
                 device,
                 &config.into(),
                 output_consumer,
                 output_channels,
-                error_notify,
+                error_callback,
             )?,
             _ => return Err(Error::Config("Unsupported sample format".to_string())),
         };
@@ -546,14 +546,14 @@ impl AudioOutputHandle {
 /// * `config` - Stream configuration (sample rate, channels, etc.)
 /// * `output_consumer` - Ring buffer consumer for f32 samples from the processor
 /// * `output_channels` - Number of output channels
-/// * `error_notify` - Optional notify handle for stream errors
+/// * `error_callback` - Optional callback for stream errors
 #[cfg(not(feature = "mock-audio"))]
 fn build_output_stream_with_format<T>(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
     mut output_consumer: rtrb::Consumer<f32>,
     output_channels: usize,
-    error_notify: Option<Arc<Notify>>,
+    mut error_callback: Option<StreamErrorCallback>,
 ) -> Result<SendStream, Error>
 where
     T: Sample + cpal::SizedSample + cpal::FromSample<f32> + Send + 'static,
@@ -658,9 +658,10 @@ where
             }
         },
         move |err| {
-            error!(error = %err, "output_stream_error");
-            if let Some(ref notify) = error_notify {
-                notify.notify_one();
+            if let Some(callback) = error_callback.as_mut() {
+                callback(err);
+            } else {
+                error!(error = %err, "output_stream_error");
             }
         },
         None,

--- a/rust/telepathy-core/src/internal/helpers.rs
+++ b/rust/telepathy-core/src/internal/helpers.rs
@@ -300,6 +300,7 @@ where
         let (codec_enabled, vbr, residual_bits) = codec_options;
         // Channel for receiving processed audio data
         let (sender, receiver) = kanal::unbounded_async();
+        let input_end_call = end_call.clone();
 
         let mut builder = AudioInputBuilder::new()
             .device(self.core_state.input_device.lock().await.clone())
@@ -307,7 +308,10 @@ where
             .rms_threshold_shared(&self.core_state.rms_threshold)
             .muted_shared(&self.core_state.muted)
             .rms_shared(&statistics_state.input_rms)
-            .on_error(end_call)
+            .on_error(move |error| {
+                error!(error = %error, "input_stream_error");
+                input_end_call.notify_one();
+            })
             .sink(KanalSink::new(sender));
 
         if codec_enabled {
@@ -362,7 +366,10 @@ where
             .rms_shared(&statistics_state.output_rms)
             .loss_shared(&statistics_state.loss)
             .codec(codec_enabled)
-            .on_error(end_call)
+            .on_error(move |error| {
+                error!(error = %error, "output_stream_error");
+                end_call.notify_one();
+            })
             .build(&self.host)?;
 
         Ok(OutputHelper::new(handle, sender))


### PR DESCRIPTION
## Summary
Audio stream builders now expose the actual CPAL stream error to callers instead of only accepting a notify handle. Callers can decide how to log, recover, or end calls, while builders still log stream errors by default when no callback is supplied.

The core call setup preserves existing behavior by logging input/output stream failures and notifying `end_call` from the new callback.

Resolves #12

## Verification
- `cargo fmt --manifest-path rust/Cargo.toml --all`
- `cargo check --manifest-path rust/Cargo.toml -p telepathy-audio`
- `cargo check --manifest-path rust/Cargo.toml -p telepathy_core`
- `cargo check --manifest-path rust/Cargo.toml -p telepathy-audio --features mock-audio`
- `cargo check --manifest-path rust/Cargo.toml -p telepathy_core --features mock-audio`
- `cargo clippy --manifest-path rust/Cargo.toml -p telepathy-audio`
- `cargo clippy --manifest-path rust/Cargo.toml -p telepathy_core`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt-5.5](https://img.shields.io/badge/gpt--5.5-000000)
