### PR TITLE
fix: reject invalid profile names

### DIFF
--- a/lib/screens/settings/sections/profiles.dart
+++ b/lib/screens/settings/sections/profiles.dart
@@ -17,13 +17,37 @@ class ProfileSettings extends StatefulWidget {
 
 class ProfileSettingsState extends State<ProfileSettings> {
   final TextEditingController _profileNameInput = TextEditingController();
+  String? _profileNameError;
 
   void _createProfile(
     BuildContext dialogContext,
     ProfilesController profilesController,
+    StateSetter setDialogState,
   ) {
-    profilesController.createProfile(_profileNameInput.text);
+    final profileName = _profileNameInput.text.trim();
+
+    if (profileName.isEmpty) {
+      setDialogState(() {
+        _profileNameError = 'Profile name is required.';
+      });
+      return;
+    }
+
+    final profileNameExists = profilesController.profiles.values.any(
+      (Profile profile) =>
+          profile.nickname.trim().toLowerCase() == profileName.toLowerCase(),
+    );
+
+    if (profileNameExists) {
+      setDialogState(() {
+        _profileNameError = 'A profile named "$profileName" already exists.';
+      });
+      return;
+    }
+
+    profilesController.createProfile(profileName);
     _profileNameInput.clear();
+    _profileNameError = null;
     Navigator.of(dialogContext).pop();
   }
 
@@ -157,37 +181,52 @@ class ProfileSettingsState extends State<ProfileSettings> {
             padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 20),
             child: IconButton(
               onPressed: () {
+                _profileNameError = null;
                 showDialog(
                     context: context,
                     builder: (BuildContext context) {
-                      return CallbackShortcuts(
-                        bindings: <ShortcutActivator, VoidCallback>{
-                          const SingleActivator(LogicalKeyboardKey.enter): () =>
-                              _createProfile(context, profilesController),
-                        },
-                        child: SimpleDialog(
-                          title: const Text('Create Profile'),
-                          contentPadding: const EdgeInsets.only(
-                              bottom: 25, left: 25, right: 25),
-                          titlePadding: const EdgeInsets.only(
-                              top: 25, left: 25, right: 25, bottom: 15),
-                          children: [
-                            TextField(
-                              decoration: const InputDecoration(
-                                labelText: 'Name',
-                              ),
-                              controller: _profileNameInput,
-                              onSubmitted: (_) =>
-                                  _createProfile(context, profilesController),
+                      return StatefulBuilder(
+                        builder:
+                            (BuildContext context, StateSetter setDialogState) {
+                          return CallbackShortcuts(
+                            bindings: <ShortcutActivator, VoidCallback>{
+                              const SingleActivator(LogicalKeyboardKey.enter):
+                                  () => _createProfile(context,
+                                      profilesController, setDialogState),
+                            },
+                            child: SimpleDialog(
+                              title: const Text('Create Profile'),
+                              contentPadding: const EdgeInsets.only(
+                                  bottom: 25, left: 25, right: 25),
+                              titlePadding: const EdgeInsets.only(
+                                  top: 25, left: 25, right: 25, bottom: 15),
+                              children: [
+                                TextField(
+                                  decoration: InputDecoration(
+                                    labelText: 'Name',
+                                    errorText: _profileNameError,
+                                  ),
+                                  controller: _profileNameInput,
+                                  onChanged: (_) {
+                                    if (_profileNameError == null) return;
+
+                                    setDialogState(() {
+                                      _profileNameError = null;
+                                    });
+                                  },
+                                  onSubmitted: (_) => _createProfile(context,
+                                      profilesController, setDialogState),
+                                ),
+                                const SizedBox(height: 20),
+                                Button(
+                                  text: 'Create',
+                                  onPressed: () => _createProfile(context,
+                                      profilesController, setDialogState),
+                                )
+                              ],
                             ),
-                            const SizedBox(height: 20),
-                            Button(
-                              text: 'Create',
-                              onPressed: () =>
-                                  _createProfile(context, profilesController),
-                            )
-                          ],
-                        ),
+                          );
+                        },
                       );
                     });
               },

--- a/lib/screens/settings/sections/profiles.dart
+++ b/lib/screens/settings/sections/profiles.dart
@@ -30,6 +30,21 @@ class ProfileSettingsState extends State<ProfileSettings> {
     return InputDecoration(
       labelText: 'Name',
       errorText: _profileNameError,
+      labelStyle: WidgetStateTextStyle.resolveWith((Set<WidgetState> states) {
+        return TextStyle(
+          color: states.contains(WidgetState.hovered)
+              ? errorHoverColor
+              : errorColor,
+        );
+      }),
+      floatingLabelStyle:
+          WidgetStateTextStyle.resolveWith((Set<WidgetState> states) {
+        return TextStyle(
+          color: states.contains(WidgetState.hovered)
+              ? errorHoverColor
+              : errorColor,
+        );
+      }),
       border: WidgetStateInputBorder.resolveWith((Set<WidgetState> states) {
         final hovered = states.contains(WidgetState.hovered);
         final focused = states.contains(WidgetState.focused);

--- a/lib/screens/settings/sections/profiles.dart
+++ b/lib/screens/settings/sections/profiles.dart
@@ -19,6 +19,31 @@ class ProfileSettingsState extends State<ProfileSettings> {
   final TextEditingController _profileNameInput = TextEditingController();
   String? _profileNameError;
 
+  InputDecoration _profileNameInputDecoration(BuildContext context) {
+    if (_profileNameError == null) {
+      return const InputDecoration(labelText: 'Name');
+    }
+
+    final errorColor = Theme.of(context).colorScheme.error;
+    final errorHoverColor = Color.lerp(errorColor, Colors.black, 0.16)!;
+
+    return InputDecoration(
+      labelText: 'Name',
+      errorText: _profileNameError,
+      border: WidgetStateInputBorder.resolveWith((Set<WidgetState> states) {
+        final hovered = states.contains(WidgetState.hovered);
+        final focused = states.contains(WidgetState.focused);
+
+        return UnderlineInputBorder(
+          borderSide: BorderSide(
+            color: hovered ? errorHoverColor : errorColor,
+            width: focused ? 2 : 1,
+          ),
+        );
+      }),
+    );
+  }
+
   void _createProfile(
     BuildContext dialogContext,
     ProfilesController profilesController,
@@ -202,10 +227,8 @@ class ProfileSettingsState extends State<ProfileSettings> {
                                   top: 25, left: 25, right: 25, bottom: 15),
                               children: [
                                 TextField(
-                                  decoration: InputDecoration(
-                                    labelText: 'Name',
-                                    errorText: _profileNameError,
-                                  ),
+                                  decoration:
+                                      _profileNameInputDecoration(context),
                                   controller: _profileNameInput,
                                   onChanged: (_) {
                                     if (_profileNameError == null) return;

--- a/test/screens/settings/sections/profiles_test.dart
+++ b/test/screens/settings/sections/profiles_test.dart
@@ -60,6 +60,46 @@ void main() {
     expect(find.text('Button Profile'), findsOneWidget);
     expect(profilesController.createdNames, <String>['Button Profile']);
   });
+
+  testWidgets('Create button rejects empty profile names', (
+    WidgetTester tester,
+  ) async {
+    final profilesController = FakeProfilesController();
+
+    await tester.pumpProfileSettings(profilesController);
+    await tester.openCreateProfileDialog();
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Profile'), findsOneWidget);
+    expect(find.text('Profile name is required.'), findsOneWidget);
+    expect(profilesController.createdNames, isEmpty);
+  });
+
+  testWidgets('create dialog rejects duplicate profile names', (
+    WidgetTester tester,
+  ) async {
+    final profilesController = FakeProfilesController();
+
+    await profilesController.createProfile('Existing Profile');
+    profilesController.createdNames.clear();
+
+    await tester.pumpProfileSettings(profilesController);
+    await tester.openCreateProfileDialog();
+
+    await tester.enterText(find.byType(TextField), '  existing profile  ');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Profile'), findsOneWidget);
+    expect(
+      find.text('A profile named "existing profile" already exists.'),
+      findsOneWidget,
+    );
+    expect(profilesController.createdNames, isEmpty);
+  });
 }
 
 extension on WidgetTester {
@@ -155,6 +195,9 @@ class FakeTelepathy implements Telepathy {
 
   @override
   Future<void> sendChat({required ChatMessage message}) async {}
+
+  @override
+  void setContactOutputVolume({required Contact contact}) {}
 
   @override
   void setDeafened({required bool deafened}) {}


### PR DESCRIPTION
## Summary

Profile creation now validates the entered name before saving. Empty or whitespace-only names stay in the dialog with a required-name message, and duplicate names are blocked using trimmed, case-insensitive comparison so users get a clear explanation instead of another indistinguishable profile.

Fixes #14.

## Test Plan

- `flutter test test/screens/settings/sections/profiles_test.dart`
- `dart format --set-exit-if-changed lib/screens/settings/sections/profiles.dart test/screens/settings/sections/profiles_test.dart`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)
